### PR TITLE
Fix react and spec

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -154,6 +154,7 @@
 
                          ;; App deps
                          [org.clojure/clojurescript "1.9.293"  :scope "test"]
+                         [org.clojure/test.check "0.9.0"] ;; AR - at the moment we need it, see http://dev.clojure.org/jira/browse/CLJS-1792
                          [adzerk/env "0.4.0"]
                          [binaryage/oops "0.5.2"]
                          [cljsjs/d3 "4.3.0-2"]

--- a/src/shared/rest_resources_viz/spec.cljc
+++ b/src/shared/rest_resources_viz/spec.cljc
@@ -1,10 +1,5 @@
 (ns rest-resources-viz.spec
-  (:require [clojure.spec :as s]
-            [clojure.spec.test :as stest]
-            [clojure.test.check.generators :as gen]))
-
-(defn instrument-all []
-  (run! stest/instrument (stest/instrumentable-syms)))
+  (:require [clojure.spec :as s]))
 
 (def qual-or-unqual-keyword? #(or (keyword? %) (qualified-keyword? %)))
 

--- a/src/shared/rest_resources_viz/spec.cljc
+++ b/src/shared/rest_resources_viz/spec.cljc
@@ -54,3 +54,8 @@
                                            :graph-data/list-of-relationship
                                            :graph-data/pagination-relationship
                                            :graph-data/alias-relationship]))
+
+;; Spec for the frontend data, is it worth having it here?
+(s/def :graph/family->index (s/map-of string? int? :conform-keys true))
+(s/def :graph/colors (s/coll-of string? :kind vector?))
+(s/def :graph/family-id string?)

--- a/src/task/rest_resources_viz/extractor.clj
+++ b/src/task/rest_resources_viz/extractor.clj
@@ -18,6 +18,9 @@
             [com.rpl.specter :as sp]
             [rest-resources-viz.spec :as rspec]))
 
+(defn instrument-all []
+  (run! stest/instrument (stest/instrumentable-syms)))
+
 (defn remove-nils [m]
   (let [f (fn [x]
             (if (map? x)

--- a/src/web/main.cljs.edn
+++ b/src/web/main.cljs.edn
@@ -1,2 +1,3 @@
 {:require [rest-resources-viz.core]
+ :compiler-options {"goog.DEBUG" true}
  :boot-reload {:on-jsload rest-resources-viz.core/on-jsload}}

--- a/src/web/rest_resources_viz/core.cljs
+++ b/src/web/rest_resources_viz/core.cljs
@@ -270,8 +270,9 @@
       (.force "y" (js/d3.forceY (/ (get-in attrs [:graph :height]) 2)))))
 
 (defn graph-enter! [state]
-  (let [margin (:margin @state)
-        attrs (:attrs @state)
+  (let [attrs (:attrs @state)
+        width @(r/track get-width state)
+        height @(r/track get-height state)
         family-by-name @(r/track get-indexed-families state)
         node-js-data @(r/track get-js-nodes state)
         link-js-data @(r/track get-js-links state)]
@@ -290,7 +291,6 @@
                          (append-node! attrs family-by-name)
                          (install-drag! d3-simulation)
                          (install-node-events! d3-tooltip attrs))]
-
         (install-graph-events!)
         (.on d3-simulation "tick" (fn []
                                     (-> d3-links
@@ -299,7 +299,12 @@
                                         (.attr "x2" #(o/oget % "target.x"))
                                         (.attr "y2" #(o/oget % "target.y")))
                                     (-> d3-nodes
-                                        (.attr "transform" #(translate-str (o/oget % "x") (o/oget % "y"))))))))))
+                                        (.attr "cx" #(let [r (o/oget % "radius")]
+                                                       (max r (min (- width r) (o/oget % "x")))))
+                                        (.attr "cy" #(let [r (o/oget % "radius")]
+                                                       (max r (min (- height r) (o/oget % "y"))))))))))))
+
+
 
 (defn graph-exit! [state]
   (let [node-js-data @(r/track get-js-nodes state)

--- a/src/web/rest_resources_viz/core.cljs
+++ b/src/web/rest_resources_viz/core.cljs
@@ -320,16 +320,6 @@
   (graph-update! state)
   (graph-exit! state))
 
-(defn stop-simulation!
-  "Helper for stopping the force simulation"
-  [state]
-  (.stop (:simulation @state)))
-
-(defn start-simulation!
-  "Helper for stopping the force simulation"
-  [state]
-  (.restart (:simulation @state)))
-
 (defn reset-state! []
   (reset! app-state init-state)
   (fetch-data!)
@@ -344,17 +334,6 @@
 (defn btn-reset [state]
   [:button.btn {:on-click #(reset-state!)}
    "Reset state"])
-
-(defn btn-toggle-simulation [state]
-  (let [stopped? (r/atom false)]
-    (fn []
-      [:button.btn
-       {:on-click #(if @stopped?
-                     (do (start-simulation! state) (reset! stopped? false))
-                     (do (stop-simulation! state) (reset! stopped? true)))}
-       (if @stopped?
-         "Stop simulation"
-         "Start simulation")])))
 
 (defn svg-markers []
   [:defs
@@ -399,10 +378,10 @@
 
 (defn landing [state]
   [:div
-   [:div.row
-    [btn-reset state]
-    [btn-draw state]
-    [btn-toggle-simulation state]]
+   (when u/debug?
+     [:div.row
+      [btn-reset state]
+      [btn-draw state]])
    [graph state]
    [console state]])
 

--- a/src/web/rest_resources_viz/core.cljs
+++ b/src/web/rest_resources_viz/core.cljs
@@ -18,15 +18,14 @@
 (env/def
   RESOURCE_DATA_URL "graph-data.edn")
 
-
-(def init-state {:margin {:top 20 :right 60 :bottom 20 :left 60}
-                 :width 960
-                 :height 820
-                 :attrs {:graph {:strength -70}
+(def init-state {:attrs {:graph {:margin {:top 20 :right 60 :bottom 20 :left 60}
+                                 :width 960
+                                 :height 820}
                          :node {:colors ["#000000" "#0cc402" "#fc0a18" "#aea7a5" "#5dafbd" "#d99f07" "#11a5fe" "#037e43" "#ba4455" "#d10aff" "#9354a6" "#7b6d2b" "#08bbbb" "#95b42d" "#b54e04" "#ee74ff" "#2d7593" "#e19772" "#fa7fbe" "#62bd33" "#aea0db" "#905e76" "#92b27a" "#03c262" "#878aff" "#4a7662" "#ff6757" "#fe8504" "#9340e1" "#2a8602" "#07b6e5" "#d21170" "#526ab3" "#015eff" "#bb2ea7" "#09bf91" "#90624c" "#bba94a" "#a26c05"]
                                 :base-radius 8
-                                :default-color "steelblue"}
-                         :link {:distance 30}
+                                :default-color "steelblue"
+                                :strength -120}
+                         :link {:distance 62}
                          :tooltip {:width 100 :height 20
                                    :padding 10 :stroke-width 2
                                    :rx 5 :ry 5
@@ -145,12 +144,12 @@
   (clj->js @(r/track! get-relationships state)))
 
 (defn get-width [state]
-  (let [margin (:margin @state)]
-    (- (:width @state) (:right margin) (:left margin))))
+  (let [margin (get-in @state [:attrs :graph :margin])]
+    (- (get-in @state [:attrs :graph :width]) (:right margin) (:left margin))))
 
 (defn get-height [state]
-  (let [margin (:margin @state)]
-    (- (:height @state) (:top margin) (:bottom margin))))
+  (let [margin (get-in @state [:graph :margin])]
+    (- (get-in @state [:attrs :graph :height]) (:top margin) (:bottom margin))))
 
 (s/fdef get-node-color
   :args (s/cat :colors :graph/colors
@@ -266,8 +265,9 @@
                          (.id #(o/oget % "id"))))
       (.force "collide" (js/d3.forceCollide #(o/oget % "radius")))
       (.force "charge" (-> (js/d3.forceManyBody)
-                           (.strength (get-in attrs [:graph :strength]))))
-      (.force "center" (js/d3.forceCenter))))
+                           (.strength (get-in attrs [:node :strength]))))
+      (.force "x" (js/d3.forceX (/ (get-in attrs [:graph :width]) 2)))
+      (.force "y" (js/d3.forceY (/ (get-in attrs [:graph :height]) 2)))))
 
 (defn graph-enter! [state]
   (let [margin (:margin @state)

--- a/src/web/rest_resources_viz/logging.clj
+++ b/src/web/rest_resources_viz/logging.clj
@@ -3,7 +3,8 @@
     rest-resources-viz.logging)
 
 (defmacro debug [& args]
-  `(.log js/console ~@args))
+  `(when ^boolean js/goog.DEBUG
+     (.log js/console ~@args)))
 
 (defmacro info [& args]
   `(.info js/console ~@args))

--- a/src/web/rest_resources_viz/util.cljs
+++ b/src/web/rest_resources_viz/util.cljs
@@ -5,6 +5,8 @@
   (:import [goog object]
            [goog.net XhrIo]))
 
+(defonce debug? ^boolean js/goog.DEBUG)
+
 (defn keyword->str [k]
   (str (if-let [n (namespace k)] (str n "/")) (name k)))
 


### PR DESCRIPTION
A refactoring PR, fixes also the React life cycle which was broken, now the app is reactive to state change and most importantly the graph pops out when `on-jsload` is called.