### PR TITLE
The rest-resource xml descriptions use CDATA and the xml parser will …

### DIFF
--- a/src/task/rest_resources_viz/extractor.clj
+++ b/src/task/rest_resources_viz/extractor.clj
@@ -50,7 +50,7 @@
      (update m1 k2 (fn [v1]
                      ;; AR - this was tough
                      (if (and (nil? v1) (string? v2))
-                       v2
+                       (str/replace (str/trim v2) "\n" " ")
                        (conj
                         (cond
                           (nil? v1) []


### PR DESCRIPTION
…use the content as-is, meaning all the newlines, tabs and whitespace are left. This change trims and replaces the extra whitespace to make the docs more readable.