### PR TITLE
Highlight nodes by their family

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -125,7 +125,7 @@
                                    [adzerk/env "0.4.0"]
                                    [binaryage/oops "0.5.2"]
                                    [cljsjs/d3 "4.3.0-3"]
-                                   [reagent "0.6.0"]]})
+                                   [reagent "0.6.2"]]})
 
 (def conf-web-prod {:env env-web-prod
                     :pipeline '(comp (adzerk.boot-cljs/cljs)
@@ -149,8 +149,8 @@
                            [com.cemerick/piggieback "0.2.1"  :scope "test"]
                            [weasel "0.7.0"  :scope "test"]
                            [org.clojure/tools.nrepl "0.2.12" :scope "test"]
-                           [binaryage/devtools "0.8.3" :scope "test"]
-                           [powerlaces/boot-cljs-devtools "0.1.3-SNAPSHOT" :scope "test"]
+                           [binaryage/devtools "0.9.4" :scope "test"]
+                           [powerlaces/boot-cljs-devtools "0.2.0" :scope "test"]
                            [pandeiro/boot-http "0.7.6" :scope "test"]
                            [crisptrutski/boot-cljs-test "0.2.2" :scope "test"]]))
 

--- a/src/web/rest_resources_viz/core.cljs
+++ b/src/web/rest_resources_viz/core.cljs
@@ -46,6 +46,8 @@
   (stest/instrument 'rest-resources-viz.model/get-node-color)
   (stest/instrument 'rest-resources-viz.model/node-id)
   (stest/instrument 'rest-resources-viz.model/highligthed-nodes)
+  (stest/instrument 'rest-resources-viz.model/clicked-node)
+  (stest/instrument 'rest-resources-viz.model/clicked-family)
   (stest/instrument 'rest-resources-viz.graph.families/highlighted-family?))
 
 (defn ^:export on-jsload []

--- a/src/web/rest_resources_viz/core.cljs
+++ b/src/web/rest_resources_viz/core.cljs
@@ -43,7 +43,10 @@
       [btn-draw]])])
 
 (when u/debug?
-  (stest/instrument 'rest-resources-viz.core/get-node-color))
+  (stest/instrument 'rest-resources-viz.model/get-node-color)
+  (stest/instrument 'rest-resources-viz.model/node-id)
+  (stest/instrument 'rest-resources-viz.model/highligthed-nodes)
+  (stest/instrument 'rest-resources-viz.graph.families/highlighted-family?))
 
 (defn ^:export on-jsload []
   (.info js/console "Reloading Javascript...")

--- a/src/web/rest_resources_viz/graph.cljs
+++ b/src/web/rest_resources_viz/graph.cljs
@@ -1,4 +1,4 @@
-(ns ^{:doc "Namespace including graph-related component and functions"
+(ns ^{:doc "Namespace including graph-related component and functions."
       :author "Andrea Richiardi"}
     rest-resources-viz.graph
   (:require [clojure.spec :as s]

--- a/src/web/rest_resources_viz/graph.cljs
+++ b/src/web/rest_resources_viz/graph.cljs
@@ -51,7 +51,7 @@
       (.selectAll "circle")
       (.on "mouseover" #(swap! model/app-state update :hovered-node util/toggle-or-nil %))
       (.on "mouseout" #(swap! model/app-state assoc :hovered-node nil))
-      (.on "click" #(swap! model/app-state update :clicked-node util/toggle-or-nil %))))
+      (.on "click" #(swap! model/app-state model/clicked-node %))))
 
 (defn install-drag!
   [d3-selection simulation]

--- a/src/web/rest_resources_viz/graph.cljs
+++ b/src/web/rest_resources_viz/graph.cljs
@@ -49,9 +49,9 @@
 (defn install-node-events! [d3-selection attrs]
   (-> d3-selection
       (.selectAll "circle")
-      (.on "mouseover" #(swap! model/app-state update :hovered-node (partial util/toggle-or-nil %)))
+      (.on "mouseover" #(swap! model/app-state update :hovered-node util/toggle-or-nil %))
       (.on "mouseout" #(swap! model/app-state assoc :hovered-node nil))
-      (.on "click" #(swap! model/app-state update :clicked-node (partial util/toggle-or-nil %)))))
+      (.on "click" #(swap! model/app-state update :clicked-node util/toggle-or-nil %))))
 
 (defn install-drag!
   [d3-selection simulation]

--- a/src/web/rest_resources_viz/graph/families.cljs
+++ b/src/web/rest_resources_viz/graph/families.cljs
@@ -72,5 +72,6 @@
                :fill-opacity (cond
                                (and (not hovered-node) (not highlighted-nodes)) 1
                                highlighted? 1
-                               :else 0.1)}
+                               :else 0.1)
+               :onClick #(swap! model/app-state model/clicked-family (keyword family-name))}
         family-name])]))

--- a/src/web/rest_resources_viz/graph/families.cljs
+++ b/src/web/rest_resources_viz/graph/families.cljs
@@ -1,0 +1,71 @@
+(ns ^{:doc "The graph that deals with families resides here."
+      :author "Andrea Richiardi"}
+    rest-resources-viz.graph.families
+  (:require [oops.core :as o]
+            [rest-resources-viz.model :as model]
+            [rest-resources-viz.util :as util])
+  (:require-macros [rest-resources-viz.logging :as log]))
+
+(defn family-widget-font
+  [attrs line-height]
+  (max (:font-size-min attrs) (/ line-height 1.618)))
+
+(defn family-highligthed?
+  [neighbor-families-of-clicked hovered clicked family-name]
+  (let [family-of-hovered (some-> hovered (o/oget "family-id"))
+        family-of-clicked (some-> clicked (o/oget "family-id"))]
+    (cond
+      (and clicked
+           (or (= family-name family-of-clicked)
+               (contains? neighbor-families-of-clicked family-name))) true
+      (and (not clicked)
+           hovered
+           (= family-name family-of-hovered)) true
+      :else false)))
+
+(defn family-widget [attrs graph-data]
+  (let [margin (get-in attrs [:graph :margin])
+        width (get-in attrs [:graph :width])
+        height (get-in attrs [:graph :height])
+        panel-attrs (:family-widget attrs)
+        family-colors (:family-colors attrs)
+        family-index-by-name (:family-index-by-name graph-data)
+        line-height (/ (- height (:top margin) (:bottom margin)) (count family-index-by-name))
+        clicked-js-node @model/clicked-js-node-state
+        hovered-js-node @model/hovered-js-node-state
+        resources-by-id (:resources-by-id graph-data)
+        resource-neighbors-by-id (:resource-neighbors-by-id graph-data)
+        neighbor-families-of-clicked (some->> clicked-js-node
+                                              (model/node-neighbors resource-neighbors-by-id)
+                                              (map #(->> %
+                                                         (get resources-by-id)
+                                                         :family-id
+                                                         clj->js))
+                                              set)]
+    (log/debug "Clicked node" clicked-js-node)
+    (log/debug "Hovered node" hovered-js-node)
+    (log/debug "Families of clicked node" neighbor-families-of-clicked)
+    [:g {:id "family-widget-container"
+         :style {:opacity 1}}
+     (for [[i family-name] (->> family-index-by-name
+                                keys
+                                sort
+                                (map-indexed vector))
+           :let [highlighted? (family-highligthed? neighbor-families-of-clicked
+                                                   hovered-js-node
+                                                   clicked-js-node
+                                                   family-name)]]
+       ^{:key family-name}
+       [:text {:x (:left margin)
+               :y (+ (:top margin) (:bottom margin) (* i line-height))
+               :fill (model/get-node-color family-colors family-index-by-name family-name)
+               :font-size (* (cond
+                               (and (not hovered-js-node) (not clicked-js-node)) 1
+                               highlighted? 1.1
+                               :else 1)
+                             (family-widget-font panel-attrs line-height))
+               :fill-opacity (cond
+                               (and (not hovered-js-node) (not clicked-js-node)) 1
+                               highlighted? 1
+                               :else 0.1)}
+        family-name])]))

--- a/src/web/rest_resources_viz/graph/families.cljs
+++ b/src/web/rest_resources_viz/graph/families.cljs
@@ -1,7 +1,8 @@
 (ns ^{:doc "The graph that deals with families resides here."
       :author "Andrea Richiardi"}
     rest-resources-viz.graph.families
-  (:require [oops.core :as o]
+  (:require [clojure.spec :as s]
+            [oops.core :as o]
             [rest-resources-viz.model :as model]
             [rest-resources-viz.util :as util])
   (:require-macros [rest-resources-viz.logging :as log]))
@@ -12,16 +13,27 @@
        (max (:font-size-min attrs))
        (min (:font-size-max attrs))))
 
-(defn family-highligthed?
-  [neighbor-families-of-clicked hovered clicked family-name]
-  (let [family-of-hovered (some-> hovered (o/oget "family-id"))
-        family-of-clicked (some-> clicked (o/oget "family-id"))]
+(s/fdef highlighted-family?
+  :args (s/cat :hovered-node ::model/clicked-node
+               :highlighted-nodes ::model/highlighted-nodes-or-nil
+               :family-name string?)
+  :ret boolean?)
+
+(defn highlighted-family?
+  "True if the family needs to be highlighted, false otherwise."
+  [hovered-node highlighted-nodes family-name]
+  (let [family-of-hovered (some-> hovered-node (o/oget "family-id"))
+        ;; I can take the first here because the spec guarantees that only
+        ;; nodes with the same family can be selected.
+        highlighted-family (some-> highlighted-nodes
+                                   first
+                                   (o/oget "family-id"))
+        highlighted-nodes? (seq highlighted-nodes)]
     (cond
-      (and clicked
-           (or (= family-name family-of-clicked)
-               (contains? neighbor-families-of-clicked family-name))) true
-      (and (not clicked)
-           hovered
+      (and highlighted-nodes?
+           (= family-name highlighted-family)) true
+      (and (not highlighted-nodes?)
+           hovered-node
            (= family-name family-of-hovered)) true
       :else false)))
 
@@ -33,41 +45,32 @@
         family-colors (:family-colors attrs)
         family-index-by-name (:family-index-by-name graph-data)
         line-height (/ (- height (:top margin) (:bottom margin)) (count family-index-by-name))
-        clicked-js-node @model/clicked-js-node-state
-        hovered-js-node @model/hovered-js-node-state
+        highlighted-nodes @(model/track-highlighted-nodes)
+        hovered-node @model/hovered-node-state
         resources-by-id (:resources-by-id graph-data)
-        resource-neighbors-by-id (:resource-neighbors-by-id graph-data)
-        neighbor-families-of-clicked (some->> clicked-js-node
-                                              (model/node-neighbors resource-neighbors-by-id)
-                                              (map #(->> %
-                                                         (get resources-by-id)
-                                                         :family-id
-                                                         clj->js))
-                                              set)]
-    (log/debug "Clicked node" clicked-js-node)
-    (log/debug "Hovered node" hovered-js-node)
-    (log/debug "Families of clicked node" neighbor-families-of-clicked)
+        resource-neighbors-by-id (:resource-neighbors-by-id graph-data)]
+    (log/debug "Highlighted nodes" highlighted-nodes)
+    (log/debug "Hovered node" hovered-node)
     [:g {:id "family-widget-container"
          :style {:opacity 1}}
      (for [[i family-name] (->> family-index-by-name
                                 keys
                                 sort
                                 (map-indexed vector))
-           :let [highlighted? (family-highligthed? neighbor-families-of-clicked
-                                                   hovered-js-node
-                                                   clicked-js-node
+           :let [highlighted? (highlighted-family? hovered-node
+                                                   highlighted-nodes
                                                    family-name)]]
        ^{:key family-name}
        [:text {:x (:left margin)
                :y (+ (:top margin) (:bottom margin) (* i line-height))
                :fill (model/get-node-color family-colors family-index-by-name family-name)
                :font-size (* (cond
-                               (and (not hovered-js-node) (not clicked-js-node)) 1
+                               (and (not hovered-node) (not highlighted-nodes)) 1
                                highlighted? 1.1
                                :else 1)
                              (family-widget-font panel-attrs line-height))
                :fill-opacity (cond
-                               (and (not hovered-js-node) (not clicked-js-node)) 1
+                               (and (not hovered-node) (not highlighted-nodes)) 1
                                highlighted? 1
                                :else 0.1)}
         family-name])]))

--- a/src/web/rest_resources_viz/graph/families.cljs
+++ b/src/web/rest_resources_viz/graph/families.cljs
@@ -8,7 +8,9 @@
 
 (defn family-widget-font
   [attrs line-height]
-  (max (:font-size-min attrs) (/ line-height 1.618)))
+  (->> (/ line-height 1.618)
+       (max (:font-size-min attrs))
+       (min (:font-size-max attrs))))
 
 (defn family-highligthed?
   [neighbor-families-of-clicked hovered clicked family-name]

--- a/src/web/rest_resources_viz/model.cljs
+++ b/src/web/rest_resources_viz/model.cljs
@@ -1,4 +1,4 @@
-(ns ^{:doc "The namespace containing state and model-related functions"
+(ns ^{:doc "The namespace containing state and model-related functions."
       :author "Andrea Richiardi"}
     rest-resources-viz.model
   (:require [clojure.spec :as s]

--- a/src/web/rest_resources_viz/model.cljs
+++ b/src/web/rest_resources_viz/model.cljs
@@ -1,7 +1,8 @@
 (ns ^{:doc "The namespace containing state and model-related functions."
       :author "Andrea Richiardi"}
     rest-resources-viz.model
-  (:require [clojure.spec :as s]
+  (:require [oops.core :as o]
+            [clojure.spec :as s]
             [reagent.core :as r]
             [rest-resources-viz.xform :as xform])
   (:require-macros [rest-resources-viz.logging :as log]))
@@ -181,3 +182,7 @@
 
 (defn get-node-color [colors family-index-by-name family-name]
   (get colors (get family-index-by-name family-name)))
+
+(defn node-neighbors
+  [resource-neighbors-by-id js-node]
+  (get resource-neighbors-by-id (-> js-node (o/oget "id") keyword)))

--- a/src/web/rest_resources_viz/model.cljs
+++ b/src/web/rest_resources_viz/model.cljs
@@ -15,7 +15,7 @@
                                 :strength -100}
                          :link {:distance 42}
                          :text {:dx 8}
-                         :family-panel {:font-size-min "9"}
+                         :family-widget {:font-size-min "8" :font-size-max "20"}
                          :tooltip {:width 100 :height 20
                                    :padding 10 :stroke-width 2
                                    :rx 5 :ry 5

--- a/src/web/rest_resources_viz/util.cljs
+++ b/src/web/rest_resources_viz/util.cljs
@@ -46,7 +46,7 @@
 (defn toggle-or-nil
   "Simple toggle-like schema, return new iff old is nil or not the same
   as new. Otherwise return nil."
-  [new old]
+  [old new]
   (cond
     (nil? old) new
     (= old new) nil

--- a/src/web/rest_resources_viz/util.cljs
+++ b/src/web/rest_resources_viz/util.cljs
@@ -42,3 +42,12 @@
   "Return the translate string needed for the transform attribute"
   [x y]
   (str "translate(" x "," y ")"))
+
+(defn toggle-or-nil
+  "Simple toggle-like schema, return new iff old is nil or not the same
+  as new. Otherwise return nil."
+  [new old]
+  (cond
+    (nil? old) new
+    (= old new) nil
+    :else new))

--- a/web-assets/css/style.css
+++ b/web-assets/css/style.css
@@ -33,13 +33,10 @@ body {
     pointer-events: auto;
 }
 
-#family-panel-container text {
+#family-widget-container text {
     font-family: sans-serif;
     font-weight: bold;
-    pointer-events: none;
-}
-
-#family-panel-container text tspan {
+    pointer-events: all;
     -webkit-transition: all 0.4s ease-in-out;
     transition: all 0.4s ease-in-out;
 }


### PR DESCRIPTION
This feature allows a user to click on the family widget on the left and have
the graph highlight nodes (and their neighbors).